### PR TITLE
# Standard mappings should not mutate with use

### DIFF
--- a/lib/ndr_import/mapper.rb
+++ b/lib/ndr_import/mapper.rb
@@ -29,12 +29,18 @@ module NdrImport::Mapper
   # Returns the standard_mapping hash specified
   # Assumes mappping exists
   def standard_mapping(mapping_name, column_mapping)
-    mapping = NdrImport::StandardMappings.mappings[mapping_name]
-    return nil if mapping.nil?
-    if column_mapping['mappings']
-      mapping['mappings'] = mapping['mappings'] + column_mapping.delete('mappings')
-    end
-    mapping.merge(column_mapping)
+    standard_mapping = NdrImport::StandardMappings.mappings[mapping_name]
+    return nil if standard_mapping.nil?
+
+    # Work on deep copies of reference standard mapping,
+    # as well as the given column_mapping:
+    reference = YAML.load(standard_mapping.to_yaml)
+    incoming  = YAML.load(column_mapping.to_yaml)
+
+    # Merge the 'mappings' key into the reference value,
+    # but replace any other keys using `incoming`:
+    reference['mappings'].concat(incoming.delete('mappings')) if incoming['mappings']
+    reference.merge!(incoming)
   end
 
   # This takes an array of raw values and their associated mappings and returns an attribute hash

--- a/test/mapper_test.rb
+++ b/test/mapper_test.rb
@@ -497,6 +497,20 @@ class MapperTest < ActiveSupport::TestCase
     end
   end
 
+  test 'should not modify the standard mapping when using it' do
+    # Take a deep copy of the original, using YAML serialization:
+    standard_mappings = YAML.load(NdrImport::StandardMappings.mappings.to_yaml)
+
+    TestMapper.new.mapped_line(['Smith'], YAML.load(<<-YML.strip_heredoc))
+      - column: surname
+        standard_mapping: surname
+        mappings:
+        - field: overwrite_surname
+    YML
+
+    assert_equal standard_mappings, NdrImport::StandardMappings.mappings
+  end
+
   test 'should join blank first field with compacting' do
     line_hash = TestMapper.new.mapped_line(['', 'CB3 0DS'], joined_mapping_blank_start)
     assert_equal 'CB3 0DS', line_hash['address']


### PR DESCRIPTION
Currently, `Mapper#standard_mapping(mapping_name, column_mapping)` can mutate both the incoming `column_mapping`, as well as the configured standard mapping for `mapping_name`.

The former is a recent regression [3c7f827d17aa], but the I think the latter is long-standing behaviour. I'm not sure if is desirable though – for example, `#validate_line_mappings` runs `#standard_mapping` before the `column_mapping` is used; we might experience unexpected behaviour with repeated attempts to mutate the same mapping.

@timgentry, could you review this change please? I'm not super-familiar with the mapper.