### PR TITLE
Remove minimum row length from delimited importers

### DIFF
--- a/lib/ndr_import/file/delimited.rb
+++ b/lib/ndr_import/file/delimited.rb
@@ -32,7 +32,7 @@ module NdrImport
         # By now, we know `encodings` should let us read the whole
         # file succesfully; if there are problems, we should crash.
         CSVLibrary.foreach(safe_path, encodings) do |line|
-          yield line.map(&:to_s) unless line.length <= 5
+          yield line.map(&:to_s)
         end
       end
 

--- a/lib/ndr_import/helpers/file/delimited.rb
+++ b/lib/ndr_import/helpers/file/delimited.rb
@@ -44,7 +44,7 @@ module NdrImport
           # By now, we know `encodings` should let us read the whole
           # file succesfully; if there are problems, we should crash.
           CSVLibrary.foreach(safe_path, encodings) do |line|
-            yield line.map(&:to_s) unless line.length <= 5
+            yield line.map(&:to_s)
           end
         end
 


### PR DESCRIPTION
@timgentry, are you aware of the reason behind these clauses? I've had a frustrating hour or so working out why my file wasn't mapping...