### PR TITLE
# Reduce allocations on replace-heavy map

### DIFF
--- a/lib/ndr_import/mapper.rb
+++ b/lib/ndr_import/mapper.rb
@@ -17,12 +17,22 @@ module NdrImport::Mapper
 
   # the replace option can be used before any other mapping option
   def replace_before_mapping(original_value, field_mapping)
-    return unless field_mapping.include?('replace') && original_value
+    return unless original_value && field_mapping.include?('replace')
 
-    [field_mapping['replace']].flatten.each do |field_replacement|
-      field_replacement.each do |pattern, replacement|
-        Array(original_value).each { |val| val.gsub!(pattern, replacement) }
-      end
+    replaces = field_mapping['replace']
+
+    if replaces.is_a?(Array)
+      replaces.each { |repls| apply_replaces(original_value, repls) }
+    else
+      apply_replaces(original_value, replaces)
+    end
+  end
+
+  def apply_replaces(value, replaces)
+    if value.is_a?(Array)
+      value.each { |val| apply_replaces(val, replaces) }
+    else
+      replaces.each { |pattern, replacement| value.gsub!(pattern, replacement) }
     end
   end
 


### PR DESCRIPTION
@timgentry ,

`replace_before_mapping` seems like a real hotspot. I've made some tweaks to reduce allocations, which is helping with replace-heavy mappings.

However, I wonder if we shouldn't implement `:pre_map` or something? Things like

```yaml
replace:
- !ruby/regexp /\Aincoming\z/i: 'type_a'
- !ruby/regexp /\Aincoming_2\z/i: 'type_a'
- !ruby/regexp /\Aanother_incoming\z/i: 'type_b'
- !ruby/regexp /\Aanother_incoming_2\z/i: 'type_b'
```

, which are applied using `gsub!`, will be much less efficient than (something like):

```yaml
pre_map:
  incoming: type_a
  incoming_2: type_a
  another_incoming: type_b
  another_incoming_2: type_b
```

and could be done with:

```ruby
mapped_value = pre_map.fetch(mapped_value, mapped_value)
```