### PR TITLE
# Change header reading behaviour and logic

### DIFF
--- a/lib/ndr_import/file/excel.rb
+++ b/lib/ndr_import/file/excel.rb
@@ -65,7 +65,11 @@ module NdrImport
         return enum_for(:xls_rows, workbook, sheet_name) unless block_given?
 
         return unless workbook.first_row(sheet_name)
-        rows    = workbook.first_row(sheet_name)..workbook.last_row(sheet_name)
+
+        # The `roo' gem deliberately skips blank lines before numbering the first
+        # non-blank line as 1, although this is undocumented.
+        # Since every spreadsheet has a first line numbered 1, use this as a hard-coded default.
+        rows    = 1..workbook.last_row(sheet_name)
         columns = workbook.first_column(sheet_name)..workbook.last_column(sheet_name)
 
         rows.each do |row|

--- a/lib/ndr_import/table.rb
+++ b/lib/ndr_import/table.rb
@@ -171,8 +171,8 @@ module NdrImport
         # don't try to match lines in a header with an incorrect number of columns
 
         # convert potential column names to lower-case, leaving nil as nil
-        header_guess = line.map {|c| c && c.downcase}
-  
+        header_guess = line.map { |c| c && c.downcase }
+
         @header_best_guess = header_guess if header_guess.any?(&:present?)
         @header_valid      = true         if header_guess == columns
       end

--- a/lib/ndr_import/table.rb
+++ b/lib/ndr_import/table.rb
@@ -57,7 +57,7 @@ module NdrImport
     end
 
     # This method process a line of data, If it is a header line it validates it, otherwise
-    # transforms it. It also increments and row index and notifies the amount of lines processed.
+    # transforms it. It also increments the row index and notifies the amount of lines processed.
     def process_line(line, &block)
       return enum_for(:process_line, line) unless block
 
@@ -167,14 +167,15 @@ module NdrImport
     def validate_header(line, column_mappings)
       columns = column_names(column_mappings)
 
-      unless line.length == columns.length
-        fail "Number of columns does not match; expected #{columns.length}, got #{line.length}!"
+      if line.length == columns.length
+        # don't try to match lines in a header with an incorrect number of columns
+
+        # convert potential column names to lower-case, leaving nil as nil
+        header_guess = line.map {|c| c && c.downcase}
+  
+        @header_best_guess = header_guess if header_guess.any?(&:present?)
+        @header_valid      = true         if header_guess == columns
       end
-
-      header_guess = line.map(&:downcase)
-
-      @header_best_guess = header_guess if header_guess.any?(&:present?)
-      @header_valid      = true         if header_guess == columns
     end
 
     def fail_unless_header_complete(column_mappings)


### PR DESCRIPTION
  The `roo' gem's first_row method returns the first /non-blank/ row.
  This method call has been replaced with a hard-coded value: 1. Every
  spreadsheet starts with row 1, including blank rows.

  Header lines are now not validated (i.e. matched with column mappings)
  if the number of columns don't match. In this way it is now possible
  to have header lines which have fewer columns than the mapping given;
  these are skipped. Note that header lines with more columns than the
  mapping will still fail validation - due to the way the grid is
  constructed in this gem.

  In header validation, columns are converted to lower-case but if
  they are nil (i.e. cell was blank) for some reason, this won't fail.
  Instead they're marked invalid as a result of the mapping not having
  blank columns.

  One test has had its name changed to reflect the skipping of header
  lines with non-matching column counts. It checks for correct reading
  of header and data lines as opposed to previously asserting an error.