### PR TITLE
Don't validate header prematurely

### DIFF
--- a/lib/ndr_import/table.rb
+++ b/lib/ndr_import/table.rb
@@ -166,7 +166,8 @@ module NdrImport
       fail ArgumentError, "Unrecognised options: #{unrecognised_options.inspect}"
     end
 
-    # if there is a header, then check the column headings are as expected in the correct order
+    # Process `line` as a candidate header row. Header validation is done
+    # lazily, once all expected header lines have been consumed.
     def consume_header_line(line, column_mappings)
       columns = column_names(column_mappings)
 
@@ -176,6 +177,8 @@ module NdrImport
       @header_valid      = true         if header_guess == columns
     end
 
+    # Once all header lines have been consumed, blow up in a
+    # helpful fashion if no valid row was found:
     def fail_unless_header_complete(column_mappings)
       return unless header_lines > 0 && !header_valid?
 

--- a/lib/ndr_import/table.rb
+++ b/lib/ndr_import/table.rb
@@ -171,8 +171,10 @@ module NdrImport
     def consume_header_line(line, column_mappings)
       columns = column_names(column_mappings)
 
-      header_guess = line.map(&:downcase)
+      header_guess = line.map { |column| column.to_s.downcase }
 
+      # The "best guess" is only if/when the header eventually deemed to be
+      # invalid - in which case, it builds the informative error message.
       @header_best_guess = header_guess if header_guess.any?(&:present?)
       @header_valid      = true         if header_guess == columns
     end

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -254,7 +254,7 @@ class TableTest < ActiveSupport::TestCase
     assert_equal expected_output, output
   end
 
-  def test_varying_header_length_with_valid_header_row
+  def test_varying_header_line_lengths_with_valid_header_row
     lines = [
       %w(NOTHEADING1 NOTHEADING2 UHOH3 UHOH4),
       %w(ONE TWO),
@@ -277,7 +277,7 @@ class TableTest < ActiveSupport::TestCase
     assert_equal expected_output, output
   end
 
-  def test_varying_header_length_with_invalid_header_row
+  def test_varying_header_line_lengths_without_valid_header_row
     lines = [
       %w(NOTHEADING1 NOTHEADING2 UHOH3 UHOH4),
       %w(ONE TWO NOPE),

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -254,6 +254,30 @@ class TableTest < ActiveSupport::TestCase
     assert_equal expected_output, output
   end
 
+  def test_varying_header_line_lengths_with_valid_header_row_including_nils
+    lines = [
+      [nil] << 'RIGHTALIGN1' << 'RIGHTALIGN2',
+      %w(ONE TWO),
+      %w(LEFTALIGN) << nil,
+      %w(CENTRE1) << nil << 'CENTRE2',
+      %w(UNO DOS)
+    ].each
+
+    table = NdrImport::Table.new(:header_lines => 4, :footer_lines => 0,
+                                 :klass => 'SomeTestKlass',
+                                 :columns => [{ 'column' => 'one' }, { 'column' => 'two' }])
+
+    output = []
+    table.transform(lines).each do |klass, fields, index|
+      output << [klass, fields, index]
+    end
+
+    assert table.header_valid?
+
+    expected_output = [['SomeTestKlass', { :rawtext => { 'one' => 'UNO', 'two' => 'DOS' } }, 4]]
+    assert_equal expected_output, output
+  end
+
   def test_varying_header_line_lengths_with_valid_header_row
     lines = [
       %w(NOTHEADING1 NOTHEADING2 UHOH3 UHOH4),


### PR DESCRIPTION
Continuing on from #9, I wonder if this branch doesn't solve the issue that @khunter68 saw without negatively affecting existing behaviour.

Previously, `fail_unless_header_complete` was used to stop if a matching header row hadn't been found in the N `header_rows` specified. However, this logic would never even be reached if one of the N rows was not of the correct length (even if the N as a whole indeed contained a valid row) – i.e. problems could arise of the header block was "non-cuboid".

@timgentry - thoughts?