### PR TITLE
# bump nokogiri, for CVE-2017-9050

### DIFF
--- a/lib/ndr_import/helpers/file/xml.rb
+++ b/lib/ndr_import/helpers/file/xml.rb
@@ -31,13 +31,16 @@ module NdrImport
           # We let slide any warnings about xml declared as one of our
           # auto encodings, but parsed as UTF-8:
           encoding_pattern = AUTO_ENCODINGS.map { |name| Regexp.escape(name) }.join('|')
-          encoding_warning = /\ADocument labelled (#{encoding_pattern}) but has UTF-8 content\z/
+          encoding_warning = /Document labelled (#{encoding_pattern}) but has UTF-8 content\z/
           fatal_errors     = document.errors.select do |error|
             error.fatal? && (encoding_warning !~ error.message)
           end
 
           return unless fatal_errors.any?
-          fail Nokogiri::XML::SyntaxError, "The file had #{fatal_errors.length} fatal error(s)!"
+          raise Nokogiri::XML::SyntaxError, <<~MSG
+            The file had #{fatal_errors.length} fatal error(s)!"
+            #{fatal_errors.join("\n")}
+          MSG
         end
       end
     end

--- a/ndr_import.gemspec
+++ b/ndr_import.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubyzip', '~> 1.2', '>= 1.2.1'
   spec.add_dependency 'roo', '~> 2.0'
 
-  spec.add_dependency 'nokogiri', '~> 1.6', '< 1.8.0'
+  spec.add_dependency 'nokogiri', '~> 1.8'
   spec.add_dependency 'roo-xls'
   spec.add_dependency 'spreadsheet', '1.0.3'
   spec.add_dependency 'pdf-reader', '1.2.0' # Raises warnings on Ruby 2.4+


### PR DESCRIPTION
@timgentry, in 47394f8790c802fe you constrained the `nokogiri` dependency because of "breaking changes".

There is a CVE which means we should upgrade; a test was failing which I've now fixed, but did you have broader concerns about what was "breaking" ?