### PR TITLE
Allow decode :word_doc to read a .docx

### DIFF
--- a/lib/ndr_import/mapper.rb
+++ b/lib/ndr_import/mapper.rb
@@ -259,7 +259,7 @@ module NdrImport::Mapper
       tempfile.write(stream.read)
 
       docx = ::Docx::Document.open(tempfile.path)
-      docx.paragraphs.map(&:to_s).join('\n')
+      docx.paragraphs.map(&:to_s).join("\n")
     end
   end
 end

--- a/test/mapper_test.rb
+++ b/test/mapper_test.rb
@@ -626,8 +626,8 @@ class MapperTest < ActiveSupport::TestCase
     test_file = @permanent_test_files.join('hello_world.docx')
     encoded_content = Base64.encode64(File.binread(test_file))
     line_hash = TestMapper.new.mapped_line([encoded_content], base64_mapping)
-    expected_content = 'Hello world, this is a modern word document\\n' \
-                       'With more than one line of text\\nThree in fact'
+    expected_content = "Hello world, this is a modern word document\n" \
+                       "With more than one line of text\nThree in fact"
 
     assert_equal expected_content, line_hash[:rawtext]['base64']
   end


### PR DESCRIPTION
Using `decode: :word_doc` currently fails with an`Ole::Storage::FormatError` if the IO stream is representing a `.docx`. This PR will attempt to decode a `.docx` in that scenario.