### PR TITLE
Add validations to field mappings

### DIFF
--- a/lib/ndr_import.rb
+++ b/lib/ndr_import.rb
@@ -1,6 +1,7 @@
 require 'ndr_import/version'
 require 'ndr_import/csv_library'
 require 'ndr_import/mapping_error'
+require 'ndr_import/missing_field_error'
 require 'ndr_import/mapper'
 require 'ndr_import/non_tabular_file_helper'
 require 'ndr_import/table'

--- a/lib/ndr_import/mapper.rb
+++ b/lib/ndr_import/mapper.rb
@@ -241,7 +241,7 @@ module NdrImport::Mapper
   end
 
   def presence_validation_on(field, value)
-    raise "#{field} #{I18n.t('errors.messages.blank')}" if value.blank?
+    raise NdrImport::MissingFieldError, field if value.blank?
   end
 
   # Decode raw_value using specified encoding

--- a/lib/ndr_import/mapper.rb
+++ b/lib/ndr_import/mapper.rb
@@ -89,8 +89,8 @@ module NdrImport::Mapper
     line.each_with_index do |raw_value, col|
       column_mapping = line_mappings[col]
       if column_mapping.nil?
-        fail ArgumentError,
-             "Line has too many columns (expected #{line_mappings.size} but got #{line.size})"
+        raise ArgumentError,
+              "Line has too many columns (expected #{line_mappings.size} but got #{line.size})"
       end
 
       next if column_mapping[Strings::DO_NOT_CAPTURE]
@@ -100,7 +100,8 @@ module NdrImport::Mapper
       end
 
       # Establish the rawtext column name we are to use for this column
-      rawtext_column_name = (column_mapping[Strings::RAWTEXT_NAME] || column_mapping[Strings::COLUMN]).downcase
+      rawtext_column_name = (column_mapping[Strings::RAWTEXT_NAME] ||
+                              column_mapping[Strings::COLUMN]).downcase
 
       # Replace raw_value with decoded raw_value
       Array(column_mapping[Strings::DECODE]).each do |encoding|
@@ -135,7 +136,9 @@ module NdrImport::Mapper
 
         if field_mapping[Strings::ORDER]
           data[field][:join] ||= field_mapping[Strings::JOIN]
-          data[field][:compact] = field_mapping[Strings::COMPACT] if field_mapping.key?(Strings::COMPACT)
+          if field_mapping.key?(Strings::COMPACT)
+            data[field][:compact] = field_mapping[Strings::COMPACT]
+          end
 
           data[field][:values][field_mapping[Strings::ORDER] - 1] = value
         elsif field_mapping[Strings::PRIORITY]
@@ -156,7 +159,7 @@ module NdrImport::Mapper
       attributes[field] =
         if field_data.key?(:join)
           # Map "blank" values to nil:
-          values = values.map { |value| value if value.present? }
+          values = values.map(&:presence)
           values.compact! if field_data[:compact]
           values.join(field_data[:join])
         else

--- a/lib/ndr_import/missing_field_error.rb
+++ b/lib/ndr_import/missing_field_error.rb
@@ -1,0 +1,14 @@
+require 'active_model' # Source I18n translations
+
+module NdrImport
+  # Raised if a mandatory field is blank.
+  class MissingFieldError < StandardError
+    attr_reader :field
+
+    def initialize(field)
+      @field = field
+      message = "#{field} #{I18n.t('errors.messages.blank')}"
+      super(message)
+    end
+  end
+end

--- a/ndr_import.gemspec
+++ b/ndr_import.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'activemodel'
   spec.add_dependency 'activesupport', '>= 3.2.18', '< 5.3'
   spec.add_dependency 'ndr_support', '>= 5.3.2', '< 6'
 

--- a/test/mapper_test.rb
+++ b/test/mapper_test.rb
@@ -377,7 +377,7 @@ class MapperTest < ActiveSupport::TestCase
   end
 
   test 'should raise an error on blank mandatory field' do
-    exception = assert_raise(RuntimeError, 'should raise an exception on blank mandatory field') do
+    exception = assert_raise(NdrImport::MissingFieldError) do
       TestMapper.new.mapped_line(['', 'RGT01'], validates_presence_mapping)
     end
     assert_equal "field_one can't be blank", exception.message

--- a/test/mapper_test.rb
+++ b/test/mapper_test.rb
@@ -293,6 +293,17 @@ class MapperTest < ActiveSupport::TestCase
           : 'RGT01'
   YML
 
+  validates_presence_mapping = YAML.safe_load <<-YML
+    - column: column_one
+      mappings:
+      - field: field_one
+        validates:
+          presence: true
+    - column: column_two
+      mappings:
+      - field: field_two
+  YML
+
   test 'map should return a number' do
     assert_equal '1', TestMapper.new.mapped_value('A', map_mapping)
   end
@@ -363,6 +374,13 @@ class MapperTest < ActiveSupport::TestCase
     original_value = ['C9999998', %w(Addenbrookes RGT01)]
     mapped_value = TestMapper.new.mapped_line(original_value, replace_array_mapping)
     assert_equal %w(RGT01 RGT01), mapped_value['hospital']
+  end
+
+  test 'should raise an error on blank mandatory field' do
+    exception = assert_raise(RuntimeError, 'should raise an exception on blank mandatory field') do
+      TestMapper.new.mapped_line(['', 'RGT01'], validates_presence_mapping)
+    end
+    assert_equal "field_one can't be blank", exception.message
   end
 
   test 'should return correct date format for date fields with daysafter' do


### PR DESCRIPTION
This PR adds the ability to specify ActiveRecord-like validations in field mappings, starting with the equivalent of https://guides.rubyonrails.org/active_record_validations.html#presence