### PR TITLE
control ndr_table serialise order with encode_with method

### DIFF
--- a/lib/ndr_import/table.rb
+++ b/lib/ndr_import/table.rb
@@ -96,7 +96,7 @@ module NdrImport
     def encode_with(coder)
       options = self.class.all_valid_options - ['columns']
       options.each do |option|
-        value = instance_variable_get("@#{option}")
+        value = send(option)
         coder[option] = value if value
       end
       coder['columns'] = @columns

--- a/lib/ndr_import/table.rb
+++ b/lib/ndr_import/table.rb
@@ -92,6 +92,16 @@ module NdrImport
       @header_valid == true
     end
 
+    # For readability, we should serialise the columns last
+    def encode_with(coder)
+      options = self.class.all_valid_options - ['columns']
+      options.each do |option|
+        value = instance_variable_get("@#{option}")
+        coder[option] = value if value
+      end
+      coder['columns'] = @columns
+    end
+
     private
 
     # This method uses a buffer to not yield the last <buffer_size> iterations of an enumerable.

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -177,9 +177,6 @@ class TableTest < ActiveSupport::TestCase
     no_coder_table_yaml_order = get_yaml_mapping_order(no_coder_table.to_yaml)
     ndr_table_yaml_order = get_yaml_mapping_order(ndr_table.to_yaml)
 
-    assert YAML.load(no_coder_table.to_yaml).is_a?(NdrImport::NonTabular::Table)
-    assert YAML.load(ndr_table.to_yaml).is_a?(NdrImport::NonTabular::Table)
-
     # no_coder_table_yaml_order => ["klass", "columns", "start_line_pattern", "end_line_pattern", "row_index"]
     # ndr_table_yaml_order => ["klass", "start_line_pattern", "end_line_pattern", "columns"]
 
@@ -188,6 +185,23 @@ class TableTest < ActiveSupport::TestCase
 
     refute no_coder_table_yaml_order.last == 'columns'
     assert ndr_table_yaml_order.last == 'columns'
+
+    # test objects deserialized from yaml mappings
+    deserialized_no_coder_table_yaml = YAML.load(no_coder_table.to_yaml)
+    deserialized_ndr_table_yaml = YAML.load(ndr_table.to_yaml)
+
+    assert deserialized_no_coder_table_yaml.is_a?(NdrImport::NonTabular::Table)
+    assert deserialized_ndr_table_yaml.is_a?(NdrImport::NonTabular::Table)
+
+    assert_nil deserialized_no_coder_table_yaml.filename_pattern
+    assert_equal deserialized_no_coder_table_yaml.klass, ndr_table.klass
+    assert_equal deserialized_no_coder_table_yaml.start_line_pattern, ndr_table.start_line_pattern
+    assert_equal deserialized_no_coder_table_yaml.columns, ndr_table.columns
+
+    assert_nil deserialized_ndr_table_yaml.filename_pattern
+    assert_equal deserialized_ndr_table_yaml.klass, ndr_table.klass
+    assert_equal deserialized_ndr_table_yaml.start_line_pattern, ndr_table.start_line_pattern
+    assert_equal deserialized_ndr_table_yaml.columns, ndr_table.columns
   end
 
   def test_skip_footer_lines

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -153,6 +153,7 @@ class TableTest < ActiveSupport::TestCase
     yaml_output = table.to_yaml
     assert yaml_output.include?('columns')
     refute yaml_output.include?('row_index')
+    assert YAML.load(yaml_output).is_a?(NdrImport::Table)
   end
 
   def test_encode_with_compare
@@ -167,12 +168,17 @@ class TableTest < ActiveSupport::TestCase
 
     assert no_coder_table.is_a?(NdrImport::Table)
     assert ndr_table.is_a?(NdrImport::Table)
+    assert no_coder_table.is_a?(NdrImport::NonTabular::Table)
+    assert ndr_table.is_a?(NdrImport::NonTabular::Table)
 
     refute no_coder_table.respond_to?(:encode_with)
     assert ndr_table.respond_to?(:encode_with)
 
     no_coder_table_yaml_order = get_yaml_mapping_order(no_coder_table.to_yaml)
     ndr_table_yaml_order = get_yaml_mapping_order(ndr_table.to_yaml)
+
+    assert YAML.load(no_coder_table.to_yaml).is_a?(NdrImport::NonTabular::Table)
+    assert YAML.load(ndr_table.to_yaml).is_a?(NdrImport::NonTabular::Table)
 
     # no_coder_table_yaml_order => ["klass", "columns", "start_line_pattern", "end_line_pattern", "row_index"]
     # ndr_table_yaml_order => ["klass", "start_line_pattern", "end_line_pattern", "columns"]

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -148,16 +148,16 @@ class TableTest < ActiveSupport::TestCase
 
     coder = {}
     table.encode_with(coder)
-    assert coder.has_key?('columns')
+    assert coder.key?('columns')
 
     yaml_output = table.to_yaml
     assert yaml_output.include?('columns')
     refute yaml_output.include?('row_index')
   end
-  
+
   def test_encode_with_compare
     table_options = {
-      columns: ['a', 'b'],
+      columns: %w[a b],
       klass: 'SomeKlass',
       start_line_pattern: 'TODO',
       end_line_pattern: 'TODO'
@@ -179,7 +179,7 @@ class TableTest < ActiveSupport::TestCase
 
     assert no_coder_table_yaml_order.include?('row_index')
     refute ndr_table_yaml_order.include?('row_index')
-    
+
     refute no_coder_table_yaml_order.last == 'columns'
     assert ndr_table_yaml_order.last == 'columns'
   end
@@ -453,9 +453,8 @@ YML
   end
 
   def get_yaml_mapping_order(yaml_mapping)
-    yaml_mapping.split("\n")
-      .delete_if {|line| /-+/.match(line) }
-      .map{|line| /(.*):/.match(line)[1].to_s }
+    yaml_mapping.split("\n").
+      delete_if { |line| /-+/.match(line) }.
+      map { |line| /(.*):/.match(line)[1].to_s }
   end
-
 end

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -194,9 +194,9 @@ class TableTest < ActiveSupport::TestCase
     assert deserialized_ndr_table_yaml.is_a?(NdrImport::NonTabular::Table)
 
     assert_nil deserialized_no_coder_table_yaml.filename_pattern
-    assert_equal deserialized_no_coder_table_yaml.klass, ndr_table.klass
-    assert_equal deserialized_no_coder_table_yaml.start_line_pattern, ndr_table.start_line_pattern
-    assert_equal deserialized_no_coder_table_yaml.columns, ndr_table.columns
+    assert_equal deserialized_no_coder_table_yaml.klass, no_coder_table.klass
+    assert_equal deserialized_no_coder_table_yaml.start_line_pattern, no_coder_table.start_line_pattern
+    assert_equal deserialized_no_coder_table_yaml.columns, no_coder_table.columns
 
     assert_nil deserialized_ndr_table_yaml.filename_pattern
     assert_equal deserialized_ndr_table_yaml.klass, ndr_table.klass


### PR DESCRIPTION
# add `encode_with` method to ensure `columns` at the bottom of the mapping when serialise.

@timgentry @joshpencheon 