### PR TITLE
allow `klass` in the column level mapping to be embedded array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-*no unreleased changes*
+* Allow `klass` in the column level mapping to be embedded array.
 
 ## 8.2.0 / 2019-02-25
 ### Added

--- a/lib/ndr_import/table.rb
+++ b/lib/ndr_import/table.rb
@@ -169,7 +169,7 @@ module NdrImport
     # relate to this klass, returning the masked mappings
     def mask_mappings_by_klass(klass)
       @columns.dup.map do |mapping|
-        if Array(mapping['klass']).include?(klass)
+        if Array(mapping['klass']).flatten.include?(klass)
           mapping
         else
           { 'do_not_capture' => true }

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -285,15 +285,16 @@ class TableTest < ActiveSupport::TestCase
   end
 
   def test_mask_mappings_by_klass
-    table = NdrImport::Table.new(:header_lines => 2, :footer_lines => 1,
-                                 :columns => column_level_klass_mapping)
+    table1 = NdrImport::Table.new(:header_lines => 2, :footer_lines => 1,
+                                  :columns => column_level_klass_mapping)
+
     some_test_klass_mapping = [
       { 'column' => 'one', 'klass' => 'SomeTestKlass' },
       { 'column' => 'two', 'klass' => %w(SomeTestKlass SomeOtherKlass) },
       { 'do_not_capture' => true }
     ]
     assert_equal some_test_klass_mapping,
-                 table.send(:mask_mappings_by_klass, 'SomeTestKlass')
+                 table1.send(:mask_mappings_by_klass, 'SomeTestKlass')
 
     some_other_klass_mapping = [
       { 'do_not_capture' => true },
@@ -301,7 +302,26 @@ class TableTest < ActiveSupport::TestCase
       { 'column' => 'three', 'klass' => 'SomeOtherKlass' }
     ]
     assert_equal some_other_klass_mapping,
-                 table.send(:mask_mappings_by_klass, 'SomeOtherKlass')
+                 table1.send(:mask_mappings_by_klass, 'SomeOtherKlass')
+
+    table2 = NdrImport::Table.new(:header_lines => 2, :footer_lines => 1,
+                                  :columns => column_level_klass_mapping_embedded_klasses)
+
+    some_test_klass_mapping_embedded_klasses = [
+      { 'column' => 'one', 'klass' => 'SomeTestKlass' },
+      { 'column' => 'two', 'klass' => [['SomeTestKlass'], 'SomeOtherKlass'] },
+      { 'do_not_capture' => true }
+    ]
+    assert_equal some_test_klass_mapping_embedded_klasses,
+                 table2.send(:mask_mappings_by_klass, 'SomeTestKlass')
+
+    some_other_klass_mapping_embedded_klasses = [
+      { 'do_not_capture' => true },
+      { 'column' => 'two', 'klass' => [['SomeTestKlass'], 'SomeOtherKlass'] },
+      { 'column' => 'three', 'klass' => 'SomeOtherKlass' }
+    ]
+    assert_equal some_other_klass_mapping_embedded_klasses,
+                 table2.send(:mask_mappings_by_klass, 'SomeOtherKlass')
   end
 
   def test_valid_single_line_header
@@ -489,6 +509,14 @@ YML
     [
       { 'column' => 'one', 'klass' => 'SomeTestKlass' },
       { 'column' => 'two', 'klass' => %w(SomeTestKlass SomeOtherKlass) },
+      { 'column' => 'three', 'klass' => 'SomeOtherKlass' }
+    ]
+  end
+
+  def column_level_klass_mapping_embedded_klasses
+    [
+      { 'column' => 'one', 'klass' => 'SomeTestKlass' },
+      { 'column' => 'two', 'klass' => [['SomeTestKlass'], 'SomeOtherKlass'] },
       { 'column' => 'three', 'klass' => 'SomeOtherKlass' }
     ]
   end


### PR DESCRIPTION
Currently, if the klass is embedded array, it will mapped to ` { 'do_not_capture' => true }`.

This PR fix the above issue, therefore the yaml mapping can looks like the following:

```
--- !ruby/object:NdrImport::Table
  list_of_klasses: &list_of_klasses
    - SomeKlass#1
    - SomeKlass#2
    - SomeKlass#3
    - SomeKlass#4
    - SomeOtherKlass

  canonical_name: somename
  row_identifier: uuid
  header_lines: 0
  footer_lines: 0
  columns:
    - column: one
      klass:
      - *list_of_klasses
      - AdditionalKlass
```