### PR TITLE
ooxml_decrypt is now on RubyGems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,4 @@
 source 'https://rubygems.org'
 
-# ooxml_decrypt is not published to rubygems.org so we need to specify where it is
-gem 'ooxml_decrypt', git: 'https://github.com/timgentry/ooxml_decrypt'
-
 # Specify your gem's dependencies in ndr_import.gemspec
 gemspec

--- a/gemfiles/Gemfile.rails50
+++ b/gemfiles/Gemfile.rails50
@@ -1,8 +1,5 @@
 source 'https://rubygems.org'
 
-# ooxml_decrypt is not published to rubygems.org so we need to specify where it is
-gem 'ooxml_decrypt', git: 'https://github.com/timgentry/ooxml_decrypt'
-
 gemspec path: '..'
 
 gem 'activesupport', '~> 5.0.0'

--- a/gemfiles/Gemfile.rails51
+++ b/gemfiles/Gemfile.rails51
@@ -1,8 +1,5 @@
 source 'https://rubygems.org'
 
-# ooxml_decrypt is not published to rubygems.org so we need to specify where it is
-gem 'ooxml_decrypt', git: 'https://github.com/timgentry/ooxml_decrypt'
-
 gemspec path: '..'
 
 # Minitest 5.10.2 doesn't work with Rails version

--- a/gemfiles/Gemfile.rails52
+++ b/gemfiles/Gemfile.rails52
@@ -1,8 +1,5 @@
 source 'https://rubygems.org'
 
-# ooxml_decrypt is not published to rubygems.org so we need to specify where it is
-gem 'ooxml_decrypt', git: 'https://github.com/timgentry/ooxml_decrypt'
-
 gemspec path: '..'
 
 gem 'activesupport', '~> 5.2.0'


### PR DESCRIPTION
The shim Gemfile references to `ooxml_decrypt` are no longer needed as I have published the gem on RubyGems. There will be a bump to `v1.0.0` if my PR is accepted, which is why I have left off a version requirement.