### PR TITLE
Data loader tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ See `test/readme_test.rb` for a more complete working example.
 
 More information on the workings of the mapper are available in the [wiki](https://github.com/PublicHealthEngland/ndr_import/wiki).
 
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
 ## Contributing
 
 1. Fork it ( https://github.com/PublicHealthEngland/ndr_import/fork )

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'ndr_import'
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require 'irb'
+IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/exe/pdf_acro_form_to_yaml
+++ b/exe/pdf_acro_form_to_yaml
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+$LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + '/../lib'))
+
+require 'ndr_import/acroform_reader'
+require 'optparse'
+require 'yaml'
+
+def program_name
+  File.basename(File.expand_path(__FILE__))
+end
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: #{program_name} [options] file"
+
+  opts.on('-h', '--help', 'Prints this help') do
+    puts opts
+    exit
+  end
+end.parse!
+
+reader = NdrImport::AcroFormReader.new(ARGV[0])
+
+puts reader.fields_hash.to_yaml

--- a/exe/pdf_to_text
+++ b/exe/pdf_to_text
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+$LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + '/../lib'))
+
+require 'pdf-reader'
+require 'optparse'
+
+def program_name
+  File.basename(File.expand_path(__FILE__))
+end
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: #{program_name} [options] file"
+
+  opts.on('-h', '--help', 'Prints this help') do
+    puts opts
+    exit
+  end
+end.parse!
+
+reader = PDF::Reader.new(ARGV[0])
+
+reader.pages.each do |page|
+  # written like this, and not file.write(page.text.split("\n")),
+  # to behave in exactly the same way as the importer
+  page.text.split("\n").each do |line|
+    puts line
+  end
+end

--- a/exe/word_to_text
+++ b/exe/word_to_text
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+$LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + '/../lib'))
+
+require 'msworddoc-extractor'
+require 'optparse'
+
+def program_name
+  File.basename(File.expand_path(__FILE__))
+end
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: #{program_name} [options] file"
+
+  opts.on('-h', '--help', 'Prints this help') do
+    puts opts
+    exit
+  end
+end.parse!
+
+filename = ARGV[0]
+extension = File.extname(filename)
+raise 'This text extractor currently only works for .doc files' unless extension == '.doc'
+
+doc = MSWordDoc::Extractor.load(filename)
+
+puts doc.whole_contents

--- a/ndr_import.gemspec
+++ b/ndr_import.gemspec
@@ -12,12 +12,14 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/PublicHealthEngland/ndr_import'
   spec.license       = 'MIT'
 
-  # Exclude older versions of this gem from the package.
-  spec.files         = `git ls-files -z`.split("\x0").reject { |s| s =~ %r{^pkg/} }
-  # SECURE BNS 2018-08-06: Minimise sharing of (public-key encrypted) slack secrets in .travis.yml
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
   spec.files         -= %w[.travis.yml] # Not needed in the gem
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.bindir        = 'exe'
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activemodel'


### PR DESCRIPTION
Moving data loader tools into the gem makes them easier to maintain and ensures that they are always run using the correct dependency versions.