### PR TITLE
Add ability to stream XML files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
-*no unreleased changes*
+### Changed
+* `File::Xml` will now stream XML files by default. Use `slurp: true` for the old behaviour. (#43)
+
+### Added
+* Add `XmlStreaming` helper, for more performant handling of large XML documents with Nokogiri. (#43)
 
 ## 8.6.0 / 2019-06-07
 ### Added

--- a/lib/ndr_import/file/xml.rb
+++ b/lib/ndr_import/file/xml.rb
@@ -18,10 +18,14 @@ module NdrImport
       def rows(&block)
         return enum_for(:rows) unless block
 
-        doc = read_xml_file(@filename)
-        file_data = SafeFile.new(@filename).read
+        xpath = @options['xml_record_xpath']
 
-        stream_xml_nodes(file_data, @options['xml_record_xpath'], &block)
+        if @options['slurp']
+          doc = read_xml_file(@filename)
+          doc.xpath(xpath).each(&block)
+        else
+          each_node(@filename, xpath, &block)
+        end
       rescue StandardError => e
         raise("#{SafeFile.basename(@filename)} [#{e.class}: #{e.message}]")
       end

--- a/lib/ndr_import/file/xml.rb
+++ b/lib/ndr_import/file/xml.rb
@@ -1,5 +1,6 @@
 require 'ndr_support/safe_file'
 require 'ndr_import/helpers/file/xml'
+require 'ndr_import/helpers/file/xml_streaming'
 require_relative 'registry'
 
 module NdrImport
@@ -9,6 +10,7 @@ module NdrImport
     # This class is a xml file handler that returns a single table.
     class Xml < Base
       include NdrImport::Helpers::File::Xml
+      include NdrImport::Helpers::File::XmlStreaming
 
       private
 
@@ -17,8 +19,9 @@ module NdrImport
         return enum_for(:rows) unless block
 
         doc = read_xml_file(@filename)
+        file_data = SafeFile.new(@filename).read
 
-        doc.xpath(@options['xml_record_xpath']).each(&block)
+        stream_xml_nodes(file_data, @options['xml_record_xpath'], &block)
       rescue StandardError => e
         raise("#{SafeFile.basename(@filename)} [#{e.class}: #{e.message}]")
       end

--- a/lib/ndr_import/helpers/file/xml.rb
+++ b/lib/ndr_import/helpers/file/xml.rb
@@ -1,12 +1,15 @@
 require 'ndr_support/safe_file'
 require 'ndr_support/utf8_encoding'
 
+# require_relative 'xml_streaming'
+
 module NdrImport
   module Helpers
     module File
       # This mixin adds XML functionality to unified importers.
       module Xml
         include UTF8Encoding
+        # include XmlStreaming
 
         private
 
@@ -16,6 +19,7 @@ module NdrImport
           require 'nokogiri'
 
           Nokogiri::XML(ensure_utf8! file_data).tap do |doc|
+          # stream_xml_nodes(ensure_utf8!(file_data), '/*').tap do |doc|
             doc.encoding = 'UTF-8'
             emulate_strict_mode_fatal_check!(doc)
           end

--- a/lib/ndr_import/helpers/file/xml.rb
+++ b/lib/ndr_import/helpers/file/xml.rb
@@ -1,15 +1,12 @@
 require 'ndr_support/safe_file'
 require 'ndr_support/utf8_encoding'
 
-# require_relative 'xml_streaming'
-
 module NdrImport
   module Helpers
     module File
       # This mixin adds XML functionality to unified importers.
       module Xml
         include UTF8Encoding
-        # include XmlStreaming
 
         private
 
@@ -19,7 +16,6 @@ module NdrImport
           require 'nokogiri'
 
           Nokogiri::XML(ensure_utf8! file_data).tap do |doc|
-          # stream_xml_nodes(ensure_utf8!(file_data), '/*').tap do |doc|
             doc.encoding = 'UTF-8'
             emulate_strict_mode_fatal_check!(doc)
           end

--- a/lib/ndr_import/helpers/file/xml_streaming.rb
+++ b/lib/ndr_import/helpers/file/xml_streaming.rb
@@ -1,0 +1,67 @@
+require 'ndr_support/safe_file'
+require 'ndr_support/utf8_encoding'
+
+module NdrImport
+  module Helpers
+    module File
+      # This mixin adds XML streaming functionality to unified importers.
+      module XmlStreaming
+        private
+
+        def add_nodes(xml, nodes)
+          name, attributes = *nodes.shift
+          xml.send(name, attributes) { add_nodes(xml, nodes) if nodes.any? }
+        end
+
+        def stubs
+          # Stubs at each nesting, to apply xpath to:
+          @stubs ||= Hash.new do |hash, nodes|
+            hash[nodes.dup] = Nokogiri::XML::Builder.new do |xml|
+              add_nodes(xml, nodes.dup)
+            end.doc
+          end
+        end
+
+        def stub_match?(stack, node_xpath)
+          # Only true if the xpath matches the full stack:
+          stubs[stack].at_xpath(node_xpath) &&
+            !stubs[stack[0..-2]].at_xpath(node_xpath)
+        end
+
+        def stream_xml_nodes(file_data, node_xpath, &block)
+          require 'nokogiri'
+
+          # Track nesting as the cursor moves through the document:
+          stack       = []
+          match_depth = nil
+
+          Nokogiri::XML::Reader(file_data).each do |node|
+            case node.node_type
+            when 1 then # "start element"
+              stack.push [node.name, node.attributes]
+
+              if match_depth || !stub_match?(stack, node_xpath)
+                stack.pop if node.empty_element?
+                next
+              end
+
+              # "empty element" matches are yielded immediately, without
+              # tagging the stack as having matched, because there won't
+              # be an equivalent closing tag to end the match with later.
+              if node.empty_element?
+                stack.pop
+              else
+                match_depth = stack.length
+              end
+
+              block.call Nokogiri::XML(node.outer_xml).at("./#{node.name}")
+            when 15 then # "end element"
+              stack.pop
+              match_depth = nil if match_depth && stack.length < match_depth
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ndr_import/helpers/file/xml_streaming.rb
+++ b/lib/ndr_import/helpers/file/xml_streaming.rb
@@ -4,7 +4,13 @@ require 'ndr_support/utf8_encoding'
 module NdrImport
   module Helpers
     module File
-      # This mixin adds XML streaming functionality to unified importers.
+      # This mixin adds XML streaming functionality, to support more performant handling
+      # of large files by Nokogiri. Uses the `XML::Reader` API, and maintains a temporary
+      # DOM as the XML is streamed to allow XPath querying from the root node.
+      #
+      # If the system has `iconv` available, will attempt to verify the encoding of the
+      # file being read externally, so it can be streamed in to Ruby. Otherwise, will load
+      # the raw data in to check the encoding, but still stream it through Nokogiri's parser.
       module XmlStreaming
         # Base error for all streaming-specific issues.
         class Error < StandardError; end

--- a/lib/ndr_import/helpers/file/xml_streaming.rb
+++ b/lib/ndr_import/helpers/file/xml_streaming.rb
@@ -23,9 +23,13 @@ module NdrImport
         end
 
         def stub_match?(stack, node_xpath)
-          # Only true if the xpath matches the full stack:
-          stubs[stack].at_xpath(node_xpath) &&
-            !stubs[stack[0..-2]].at_xpath(node_xpath)
+          parent_stack = stack[0..-2]
+
+          # Only true if the xpath matches the stack...
+          return false unless stubs[stack].at_xpath(node_xpath)
+
+          # ...and the entire stack:
+          parent_stack.empty? || !stubs[parent_stack].at_xpath(node_xpath)
         end
 
         def stream_xml_nodes(file_data, node_xpath, &block)

--- a/lib/ndr_import/helpers/file/xml_streaming.rb
+++ b/lib/ndr_import/helpers/file/xml_streaming.rb
@@ -62,7 +62,7 @@ module NdrImport
               @match_depth = @stack.length
             end
 
-            return match
+            match
           end
 
           private
@@ -152,7 +152,7 @@ module NdrImport
           reader.each do |node|
             case node.node_type
             when Nokogiri::XML::Reader::TYPE_ELEMENT # "opening tag"
-              raise NestingError.new(node) if cursor.in?(node)
+              raise NestingError, node if cursor.in?(node)
 
               cursor.enter(node)
               next unless cursor.matches?

--- a/lib/ndr_import/universal_importer_helper.rb
+++ b/lib/ndr_import/universal_importer_helper.rb
@@ -38,7 +38,8 @@ module NdrImport
           'col_sep'          => table_mapping.try(:delimiter),
           'file_password'    => table_mapping.try(:file_password),
           'liberal_parsing'  => table_mapping.try(:liberal_parsing),
-          'xml_record_xpath' => table_mapping.try(:xml_record_xpath)
+          'xml_record_xpath' => table_mapping.try(:xml_record_xpath),
+          'slurp'            => table_mapping.try(:slurp)
         }
 
         tables = NdrImport::File::Registry.tables(filename, table_mapping.try(:format), options)

--- a/ndr_import.gemspec
+++ b/ndr_import.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'mocha'
-  spec.add_development_dependency 'ndr_dev_support', '~> 3.1', '>= 3.1.3'
+  spec.add_development_dependency 'ndr_dev_support', '>= 3.1.3'
   spec.add_development_dependency 'guard'
   spec.add_development_dependency 'guard-rubocop'
   spec.add_development_dependency 'guard-test'

--- a/test/file/xml_test.rb
+++ b/test/file/xml_test.rb
@@ -15,6 +15,7 @@ module NdrImport
         rows      = handler.send(:rows)
         assert rows.is_a? Enumerator
         assert(rows.all? { |row| row.is_a? Nokogiri::XML::Element })
+        assert_equal 2, rows.to_a.length
       end
     end
   end

--- a/test/file/xml_test.rb
+++ b/test/file/xml_test.rb
@@ -6,13 +6,27 @@ module NdrImport
     # Xml file handler tests
     class XmlTest < ActiveSupport::TestCase
       def setup
-        @permanent_test_files = SafePath.new('permanent_test_files')
+        @file_path = SafePath.new('permanent_test_files').join('sample.xml')
+        @options   = { 'xml_record_xpath' => 'root/record' }
       end
 
-      test 'should return enum of xml elements' do
-        file_path = @permanent_test_files.join('sample.xml')
-        handler   = NdrImport::File::Xml.new(file_path, nil, 'xml_record_xpath' => 'root/record')
-        rows      = handler.send(:rows)
+      test 'should return enum of xml stream by default' do
+        handler = NdrImport::File::Xml.new(@file_path, nil, @options)
+        handler.expects(:read_xml_file).never
+
+        rows = handler.send(:rows)
+
+        assert rows.is_a? Enumerator
+        assert(rows.all? { |row| row.is_a? Nokogiri::XML::Element })
+        assert_equal 2, rows.to_a.length
+      end
+
+      test 'should slurp xml only if asked' do
+        handler = NdrImport::File::Xml.new(@file_path, nil, @options.merge('slurp' => true))
+        handler.expects(:each_node).never
+
+        rows = handler.send(:rows)
+
         assert rows.is_a? Enumerator
         assert(rows.all? { |row| row.is_a? Nokogiri::XML::Element })
         assert_equal 2, rows.to_a.length

--- a/test/helpers/file/xml_streaming_test.rb
+++ b/test/helpers/file/xml_streaming_test.rb
@@ -126,6 +126,16 @@ class XmlStreamingTest < ActiveSupport::TestCase
     assert_equal 1, alpha_nodes.length
   end
 
+  test 'stream_xml_nodes should handle incoming declarated as UTF-16 which is not' do
+    nodes = @importer.nodes_from_file('//letter', 'claims_utf16be_but_isnt.xml')
+    punct = nodes.map(&:text).join
+
+    assert punct.valid_encoding?
+    assert_equal Encoding.find('UTF-8'), punct.encoding
+    assert_equal 2, punct.chars.to_a.length
+    assert_equal [226, 128, 153, 226, 128, 147], punct.bytes.to_a # 3 bytes each for apostrophe and dash
+  end
+
   test 'stream_xml_nodes should handle incoming Windows-1252' do
     nodes = @importer.nodes_from_file('//letter', 'windows-1252_xml.xml')
     punct = nodes.map(&:text).join

--- a/test/helpers/file/xml_streaming_test.rb
+++ b/test/helpers/file/xml_streaming_test.rb
@@ -3,7 +3,7 @@ require 'ndr_import/helpers/file/xml_streaming'
 require 'nokogiri'
 
 # XML streaming file helper tests
-class XmlTest < ActiveSupport::TestCase
+class XmlStreamingTest < ActiveSupport::TestCase
   # This is a test importer class to test the XML streaming file helper mixin
   class TestImporter
     include NdrImport::Helpers::File::XmlStreaming
@@ -38,6 +38,17 @@ class XmlTest < ActiveSupport::TestCase
     assert_equal 2, @importer.nodes('//node', <<~XML).length
       <nodes><node></node><node></node></nodes>
     XML
+  end
+
+  test 'should guard against nesting limitation' do
+    exception = assert_raises(NdrImport::Helpers::File::XmlStreaming::NestingError) do
+      @importer.nodes('//node', <<~XML).length
+        <nodes><node><node></node></node></nodes>
+      XML
+    end
+
+    assert_match(/Element 'node' was found/, exception.message)
+    assert_match(/known limitation of XmlStreaming/, exception.message)
   end
 
   test 'should be able to find the root node' do

--- a/test/helpers/file/xml_streaming_test.rb
+++ b/test/helpers/file/xml_streaming_test.rb
@@ -15,7 +15,7 @@ class XmlStreamingTest < ActiveSupport::TestCase
     end
 
     def nodes(xpath, xml)
-      file_name = 'streaming_test.xml'
+      file_name = "streaming_test_#{rand(1e9)}.xml"
       file_path = safe_path.join(file_name)
       SafeFile.open(file_path, 'w') { |f| f.write xml }
 

--- a/test/helpers/file/xml_streaming_test.rb
+++ b/test/helpers/file/xml_streaming_test.rb
@@ -8,15 +8,30 @@ class XmlTest < ActiveSupport::TestCase
   class TestImporter
     include NdrImport::Helpers::File::XmlStreaming
 
+    def initialize(safe_path)
+      @safe_path = safe_path
+    end
+
     def nodes(xpath, xml)
+      file_name = 'streaming_test.xml'
+      file_path = @safe_path.join(file_name)
+      SafeFile.open(file_path, 'w') { |f| f.write xml }
+
+      nodes_from_file(xpath, file_name)
+    ensure
+      SafeFile.delete(file_path)
+    end
+
+    def nodes_from_file(xpath, file_name)
+      file_path = @safe_path.join(file_name)
       [].tap do |nodes|
-        stream_xml_nodes(xml, xpath) { |node| nodes << node }
+        stream_xml_nodes(file_path, xpath) { |node| nodes << node }
       end
     end
   end
 
   def setup
-    @importer = TestImporter.new
+    @importer = TestImporter.new SafePath.new('permanent_test_files')
   end
 
   test 'should yield matching nodes' do
@@ -55,5 +70,72 @@ class XmlTest < ActiveSupport::TestCase
     assert_equal 'node', node.name
     assert_equal ['foo'], node.children.map(&:name)
     assert_equal 'bar', node.text
+  end
+
+  test 'stream_xml_nodes should handle incoming UTF-8' do
+    nodes = @importer.nodes_from_file('//letter', 'utf-8_xml.xml')
+    greek = nodes.map(&:text).join
+
+    assert greek.valid_encoding?
+    assert_equal Encoding.find('UTF-8'), greek.encoding
+    assert_equal 2, greek.chars.to_a.length
+    assert_equal [206, 177, 206, 178], greek.bytes.to_a # 2-bytes each for alpha and beta
+  end
+
+  test 'stream_xml_nodes should handle incoming UTF-16 (big endian)' do
+    nodes = @importer.nodes_from_file('//letter', 'utf-16be_xml.xml')
+    greek = nodes.map(&:text).join
+
+    assert greek.valid_encoding?
+    assert_equal Encoding.find('UTF-8'), greek.encoding
+    assert_equal 2, greek.chars.to_a.length
+    assert_equal [206, 177, 206, 178], greek.bytes.to_a # 2-bytes each for alpha and beta
+  end
+
+  test 'stream_xml_nodes should handle incoming UTF-16 (little endian)' do
+    nodes = @importer.nodes_from_file('//letter', 'utf-16le_xml.xml')
+    greek = nodes.map(&:text).join
+
+    assert greek.valid_encoding?
+    assert_equal Encoding.find('UTF-8'), greek.encoding
+    assert_equal 2, greek.chars.to_a.length
+    assert_equal [206, 177, 206, 178], greek.bytes.to_a # 2-bytes each for alpha and beta
+  end
+
+  test 'stream_xml_nodes should handle incoming UTF-16 with declaration' do
+    nodes = @importer.nodes_from_file('//note', 'utf-16be_xml_with_declaration.xml')
+    greek = nodes.map(&:text).join.gsub(/\s/, '')
+
+    assert greek.valid_encoding?
+    assert_equal Encoding.find('UTF-8'), greek.encoding
+    assert_equal 2, greek.chars.to_a.length
+    assert_equal [206, 177, 206, 178], greek.bytes.to_a # 2-bytes each for alpha and beta
+
+    alpha_nodes = nodes.select { |node| node.at_xpath('//note[@id="alpha"]') }
+    assert_equal 1, alpha_nodes.length
+  end
+
+  test 'stream_xml_nodes should handle incoming Windows-1252' do
+    nodes = @importer.nodes_from_file('//letter', 'windows-1252_xml.xml')
+    punct = nodes.map(&:text).join
+
+    assert punct.valid_encoding?
+    assert_equal Encoding.find('UTF-8'), punct.encoding
+    assert_equal 2, punct.chars.to_a.length
+    assert_equal [226, 128, 153, 226, 128, 147], punct.bytes.to_a # 3 bytes each for apostrophe and dash
+  end
+
+  test 'stream_xml_nodes with malformed XML file' do
+    assert_raises Nokogiri::XML::SyntaxError do
+      @importer.nodes_from_file('//note', 'malformed.xml')
+    end
+  end
+
+  test 'stream_xml_nodes should reject non safe path arguments' do
+    exception = assert_raises ArgumentError do
+      @importer.send(:stream_xml_nodes, 'unsafe.xml', '//note')
+    end
+
+    assert_match(/should be of type SafePath/, exception.message)
   end
 end

--- a/test/helpers/file/xml_streaming_test.rb
+++ b/test/helpers/file/xml_streaming_test.rb
@@ -25,6 +25,12 @@ class XmlTest < ActiveSupport::TestCase
     XML
   end
 
+  test 'should be able to find the root node' do
+    assert_equal 1, @importer.nodes('/*', <<~XML).length
+      <nodes><node></node><node></node></nodes>
+    XML
+  end
+
   test 'should yield matching nodes with attributes' do
     assert_equal 1, @importer.nodes('//nodes[@zone="a"]//node[@type="1"]', <<~XML).length
       <root>

--- a/test/helpers/file/xml_streaming_test.rb
+++ b/test/helpers/file/xml_streaming_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+require 'ndr_import/helpers/file/xml_streaming'
+require 'nokogiri'
+
+# XML streaming file helper tests
+class XmlTest < ActiveSupport::TestCase
+  # This is a test importer class to test the XML streaming file helper mixin
+  class TestImporter
+    include NdrImport::Helpers::File::XmlStreaming
+
+    def nodes(xpath, xml)
+      [].tap do |nodes|
+        stream_xml_nodes(xml, xpath) { |node| nodes << node }
+      end
+    end
+  end
+
+  def setup
+    @importer = TestImporter.new
+  end
+
+  test 'should yield matching nodes' do
+    assert_equal 2, @importer.nodes('//node', <<~XML).length
+      <nodes><node></node><node></node></nodes>
+    XML
+  end
+
+  test 'should yield matching nodes with attributes' do
+    assert_equal 1, @importer.nodes('//nodes[@zone="a"]//node[@type="1"]', <<~XML).length
+      <root>
+        <nodes zone="a"><node type="1"></node><node type="2"></node></nodes>
+        <nodes zone="b"><node type="1"></node><node type="2"></node></nodes>
+      </root>
+    XML
+  end
+
+  test 'should yield matching empty_element nodes' do
+    assert_equal 2, @importer.nodes('//node', <<~XML).length
+      <nodes><node/><node/></nodes>
+    XML
+  end
+
+  test 'should yield nokogiri elements' do
+    node = @importer.nodes('//node', <<~XML).first
+      <nodes><node><foo>bar</foo></node></nodes>
+    XML
+
+    assert_kind_of Nokogiri::XML::Element, node
+    assert_equal 'node', node.name
+    assert_equal ['foo'], node.children.map(&:name)
+    assert_equal 'bar', node.text
+  end
+end

--- a/test/helpers/file/xml_streaming_test.rb
+++ b/test/helpers/file/xml_streaming_test.rb
@@ -156,7 +156,7 @@ class XmlStreamingTest < ActiveSupport::TestCase
 
   test 'each_node should reject non safe path arguments' do
     exception = assert_raises ArgumentError do
-      blocked_called = false
+      block_called = false
       @importer.each_node('unsafe.xml', '//note') { block_called = true }
 
       refute block_called, 'should not have yielded'

--- a/test/resources/claims_utf16be_but_isnt.xml
+++ b/test/resources/claims_utf16be_but_isnt.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-16"?>
+<root>
+  <note id="apostrophe">
+    <letter>’</letter>
+  </note>
+  <note id="dash">
+    <letter>–</letter>
+  </note>
+</root>


### PR DESCRIPTION
This PR is opened for discussion, at this stage.

I've added code to allow XML documents to be streamed by Nokogiri. It makes efforts to be as efficient as possible, whilst still aiming to support the myriad of encoding weirdness scenarios that has caused headaches in the past. To that end, it'll sometimes have to drop down into a slight less efficient slurp/stream hybrid strategy.

I've switched the `File::Xml` class to stream XML by default, and provided a `slurp: true` option to allow access to the legacy behaviour.

The streaming works by chugging through the XML as a SAX parser would, and keeping a micro-DOM built to represent how far into the document's DOM structure the cursor has descended. This micro-DOM allows for XPath to still be used to detect when and element of interest has been reached, without having to retain the entire document's DOM structure in memory - it's this which becomes prohibitive for parsing large XML documents, as Nokogiri's representation inflates memory usage by an order of magnitude or more over the raw data size.