### PR TITLE
remove version restriction to spreadsheet gem

### DIFF
--- a/ndr_import.gemspec
+++ b/ndr_import.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'pdf-reader', '~> 2.1'
   spec.add_dependency 'roo-xls'
   spec.add_dependency 'seven_zip_ruby', '~> 1.2'
-  spec.add_dependency 'spreadsheet'
+  spec.add_dependency 'spreadsheet', '1.2.6'
 
   spec.required_ruby_version = '>= 2.5'
 

--- a/ndr_import.gemspec
+++ b/ndr_import.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'pdf-reader', '~> 2.1'
   spec.add_dependency 'roo-xls'
   spec.add_dependency 'seven_zip_ruby', '~> 1.2'
-  spec.add_dependency 'spreadsheet', '1.0.3'
+  spec.add_dependency 'spreadsheet'
 
   spec.required_ruby_version = '>= 2.5'
 


### PR DESCRIPTION
As discussed, we should remove legacy version restriction for spreadsheet gem.

@joshpencheon 