### PR TITLE
# ruby 2.7: ensure keyword args are properly splatted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
 - 2.5
 - 2.6
+- 2.7
 gemfile:
 - gemfiles/Gemfile.rails52
 - gemfiles/Gemfile.rails60

--- a/lib/ndr_import/csv_library.rb
+++ b/lib/ndr_import/csv_library.rb
@@ -12,8 +12,8 @@ class << CSVLibrary
 
   # Ensure that we can pass "mode" straight through the underlying IO object
   def foreach(path, **options, &block)
-    return to_enum(__method__, path, options) unless block
-    open(path, options.delete(:mode) || 'r', options) do |csv|
+    return to_enum(__method__, path, **options) unless block
+    open(path, options.delete(:mode) || 'r', **options) do |csv|
       csv.each(&block)
     end
   end

--- a/lib/ndr_import/helpers/file/delimited.rb
+++ b/lib/ndr_import/helpers/file/delimited.rb
@@ -36,7 +36,7 @@ module NdrImport
 
           # By now, we know `encodings` should let us read the whole
           # file succesfully; if there are problems, we should crash.
-          CSVLibrary.foreach(safe_path, encodings) do |line|
+          CSVLibrary.foreach(safe_path, **encodings) do |line|
             yield line.map(&:to_s)
           end
         end
@@ -73,7 +73,7 @@ module NdrImport
 
               row_num = 0
               # Iterate through the file; if we reach the end, this encoding worked:
-              CSVLibrary.foreach(safe_path, options) { |_line| row_num += 1 }
+              CSVLibrary.foreach(safe_path, **options) { |_line| row_num += 1 }
               return options
             rescue ArgumentError => e
               next if e.message =~ /invalid byte sequence/ # This encoding didn't work


### PR DESCRIPTION
This fixes deprecations emitted on Ruby 2.7.0