### PR TITLE
Remove unused code from universal import helper.

### DIFF
--- a/lib/ndr_import/universal_importer_helper.rb
+++ b/lib/ndr_import/universal_importer_helper.rb
@@ -27,7 +27,6 @@ module NdrImport
     end
 
     def table_enumerators(filename)
-      table_enumerators = {}
       table_enumerators = Hash.new { |hash, key| hash[key] = TableEnumProxy.new }
 
       extract(filename).each do |table, rows|


### PR DESCRIPTION
This PR removes a line of code that was left in by accident in #54, sorry!

There should be no observable behaviour differences; no CHANGELOG entry necessary. 