### PR TITLE
Escape control chars found in XML by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-*no unreleased changes*
+### Changed
+* By default, escape any control characters found in XML.
 
 ## 9.1.0 / 2021-02-01
 ### Added

--- a/lib/ndr_import/helpers/file/xml.rb
+++ b/lib/ndr_import/helpers/file/xml.rb
@@ -19,9 +19,7 @@ module NdrImport
 
           require 'nokogiri'
 
-          doc = Nokogiri::XML(file_data) do |config|
-            config.huge
-          end
+          doc = Nokogiri::XML(file_data, &:huge)
           doc.encoding = 'UTF-8'
           emulate_strict_mode_fatal_check!(doc)
 
@@ -44,6 +42,7 @@ module NdrImport
           end
 
           return unless fatal_errors.any?
+
           raise Nokogiri::XML::SyntaxError, <<~MSG
             The file had #{fatal_errors.length} fatal error(s)!"
             #{fatal_errors.join("\n")}

--- a/test/resources/malformed.xml
+++ b/test/resources/malformed.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <root>
-  <note><![CDATA[
-    This is  a note!
-  ]]></note>
+  <note>complete note</note>
+  <note>incomplete note
 </root>

--- a/test/resources/with-control-chars.xml
+++ b/test/resources/with-control-chars.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<broken><![CDATA[with newline
+and a cancel char: ]]></broken>


### PR DESCRIPTION
Related to internal ticket 25592, this PR proposes escaping control characters found in XML data, before handing it to Nokogiri / @libxml@ for parsing.

The background is that XML 1.0 generally [mustn't contain control characters](https://www.w3.org/TR/2006/REC-xml-20060816/Overview.html#charsets), and in XML 1.1 it's still [highly discouraged](https://www.w3.org/TR/2006/REC-xml11-20060816/#charsets). The data we tend to process is yet to provide a legitimate reason for preserving these control characters as-is downstream.

With other formats, we've settled on escaping control characters rather than stripping them, in case they are providing some semantic purpose (acting as a strange form of punctuation within a body of text, for example). However, they normally appear due to various munging that takes place between various legacy systems outside of our control, during data production.

As this PR currently changes `read_xml_file`'s default behaviour, it would constitute a major version bump. On the basis that we don't have a clear use case where we _wouldn't_ want to do this, it seemed like the pragmatic choice... but happy to discuss?