### PR TITLE
Handle invalid control character references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## [Unreleased]
-* no relevant changes
+### Fixed
+* XML: ensure invalid control character *references* are also escaped
 
 ## 10.1 / 2021-03-08
+### Added
 * Allow optional `last_data_column` in NdrImport::Table mappings (#61)
 
 ## 10.0 / 2021-02-22

--- a/lib/ndr_import/helpers/file/xml.rb
+++ b/lib/ndr_import/helpers/file/xml.rb
@@ -1,3 +1,4 @@
+require 'ndr_import/xml/control_char_escaper'
 require 'ndr_support/safe_file'
 require 'ndr_support/utf8_encoding'
 
@@ -15,13 +16,16 @@ module NdrImport
         # in XML 1.1; any found are most likely to be erroneous.
         def read_xml_file(path, preserve_control_chars: false)
           file_data = ensure_utf8!(SafeFile.read(path))
-          escape_xml_control_chars!(file_data) unless preserve_control_chars
 
           require 'nokogiri'
 
-          doc = Nokogiri::XML(file_data, &:huge)
-          doc.encoding = 'UTF-8'
-          emulate_strict_mode_fatal_check!(doc)
+          doc = nil
+
+          escaping_control_chars_if_necessary(preserve_control_chars, file_data) do
+            doc = Nokogiri::XML(file_data, &:huge)
+            doc.encoding = 'UTF-8'
+            emulate_strict_mode_fatal_check!(doc)
+          end
 
           doc
         end
@@ -49,11 +53,19 @@ module NdrImport
           MSG
         end
 
-        # In place, escape out any control chars that would cause
-        # libxml to crash. Very few are allowable in XML 1.0, and
-        # remain heavily discouraged in XML 1.1.
-        def escape_xml_control_chars!(data)
-          escape_control_chars!(data)
+        def escaping_control_chars_if_necessary(preserve_control_chars, file_data)
+          return yield if preserve_control_chars
+
+          tried_escaping = false
+          begin
+            yield
+          rescue Nokogiri::XML::SyntaxError => e
+            raise e if tried_escaping
+
+            NdrImport::Xml::ControlCharEscaper.new(file_data).escape!
+            tried_escaping = true
+            retry
+          end
         end
       end
     end

--- a/lib/ndr_import/xml/control_char_escaper.rb
+++ b/lib/ndr_import/xml/control_char_escaper.rb
@@ -1,0 +1,51 @@
+require 'ndr_support/utf8_encoding'
+
+module NdrImport
+  module Xml
+    # A class to remove control characters, and XML entities representing them
+    class ControlCharEscaper
+      include UTF8Encoding
+
+      # Matches XML character reference entities
+      CHARACTER_REFERENCES = /&#(?:(?<decimal>\d+)|x(?<hex>\h+));/.freeze
+
+      attr_reader :data
+
+      def initialize(data)
+        @data = data
+      end
+
+      def escape!
+        unescape_control_char_references!(data)
+        escape_control_chars!(data)
+      end
+
+      private
+
+      def unescape_control_char_references!(data)
+        data.gsub!(CHARACTER_REFERENCES) do |reference|
+          char = try_to_extract_char_from(Regexp.last_match)
+
+          if char&.match?(CONTROL_CHARACTERS)
+            escape_control_chars!(char)
+          else
+            reference
+          end
+        end
+      end
+
+      def try_to_extract_char_from(match)
+        if match.nil?
+          nil
+        elsif match[:decimal]
+          match[:decimal].to_i(10).chr
+        elsif match[:hex]
+          match[:hex].to_i(16).chr
+        end
+      rescue RangeError
+        # Return everything if the match was against junk:
+        match.to_s
+      end
+    end
+  end
+end

--- a/test/helpers/file/xml_test.rb
+++ b/test/helpers/file/xml_test.rb
@@ -85,10 +85,28 @@ class XmlTest < ActiveSupport::TestCase
     end
   end
 
-  test 'escaping XML file containing control chars' do
+  test 'escaping XML file containing invalid control chars' do
     doc = @importer.send(:read_xml_file, @permanent_test_files.join('with-control-chars.xml'))
     assert_empty doc.errors
-    assert_equal doc.text, "with newline\nand a cancel char: 0x18", 'should have escaped'
+    assert_equal "with newline\nand a cancel char: 0x18", doc.text, 'should have escaped'
+  end
+
+  test 'escaping XML file containing control char references within CDATA' do
+    doc = @importer.send(:read_xml_file, @permanent_test_files.join('with-control-char-references-in-cdata.xml'))
+    assert_empty doc.errors
+    assert_equal 'referencing a cancel char within CDATA: &#x18;', doc.text, 'should not have triggered escaping'
+  end
+
+  test 'escaping XML file containing invalid control char references' do
+    doc = @importer.send(:read_xml_file, @permanent_test_files.join('with-control-char-references.xml'))
+    assert_empty doc.errors
+    assert_equal 'referencing a cancel char: 0x18', doc.text, 'should have escaped'
+  end
+
+  test 'escaping XML file containing non-control char references' do
+    doc = @importer.send(:read_xml_file, @permanent_test_files.join('with-non-control-char-references.xml'))
+    assert_empty doc.errors
+    assert_equal 'referenced chars', doc.text, 'should have not escaped, and then subbed for chars'
   end
 
   test 'XML file containing control chars, opting out of escaping' do

--- a/test/resources/with-control-char-references-in-cdata.xml
+++ b/test/resources/with-control-char-references-in-cdata.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fine><![CDATA[referencing a cancel char within CDATA: &#x18;]]></fine>

--- a/test/resources/with-control-char-references.xml
+++ b/test/resources/with-control-char-references.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<broken>referencing a cancel char: &#x18;</broken>

--- a/test/resources/with-non-control-char-references.xml
+++ b/test/resources/with-non-control-char-references.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fine>referenced &#x63;&#104;&#x61;&#114;&#x73;</fine>

--- a/test/xml/control_char_escaper_test.rb
+++ b/test/xml/control_char_escaper_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-# This tests the NdrImport::Xml::Table mapping class
+# This tests the NdrImport::Xml::ControlCharEscaperTest utility class
 module Xml
   class ControlCharEscaperTest < ActiveSupport::TestCase
     def test_should_escape_in_place

--- a/test/xml/control_char_escaper_test.rb
+++ b/test/xml/control_char_escaper_test.rb
@@ -19,7 +19,7 @@ module Xml
       assert_equal 'hello 0x1c world', escape('hello &#28; world')
     end
 
-    def test_should_escape_hexidecimal_control_character_reference
+    def test_should_escape_hexadecimal_control_character_reference
       assert_equal 'hello 0x00 world', escape('hello &#x00; world')
       assert_equal 'hello 0x1c world', escape('hello &#x1C; world')
     end
@@ -32,11 +32,11 @@ module Xml
       assert_equal '&#0123456789;', escape('&#0123456789;')
     end
 
-    def test_should_not_escape_non_control_character_hexidecimal_reference
+    def test_should_not_escape_non_control_character_hexadecimal_reference
       assert_equal 'hell&#x6F; world', escape('hell&#x6F; world')
     end
 
-    def test_should_gracefully_handle_nonsense_hexidecimal_input
+    def test_should_gracefully_handle_nonsense_hexadecimal_input
       assert_equal '&#xABCDEF0123456789;', escape('&#xABCDEF0123456789;')
     end
 

--- a/test/xml/control_char_escaper_test.rb
+++ b/test/xml/control_char_escaper_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+# This tests the NdrImport::Xml::Table mapping class
+module Xml
+  class ControlCharEscaperTest < ActiveSupport::TestCase
+    def test_should_escape_in_place
+      data = "test \x1c data"
+      escape(data)
+
+      assert_equal data, 'test 0x1c data'
+    end
+
+    def test_should_escape_control_character
+      assert_equal 'hello 0x00 world', escape("hello \x00 world")
+    end
+
+    def test_should_escape_decimal_control_character_reference
+      assert_equal 'hello 0x00 world', escape('hello &#00; world')
+      assert_equal 'hello 0x1c world', escape('hello &#28; world')
+    end
+
+    def test_should_escape_hexidecimal_control_character_reference
+      assert_equal 'hello 0x00 world', escape('hello &#x00; world')
+      assert_equal 'hello 0x1c world', escape('hello &#x1C; world')
+    end
+
+    def test_should_not_escape_non_control_character_decimal_reference
+      assert_equal 'hell&#111; world', escape('hell&#111; world')
+    end
+
+    def test_should_gracefully_handle_nonsense_decimal_input
+      assert_equal '&#0123456789;', escape('&#0123456789;')
+    end
+
+    def test_should_not_escape_non_control_character_hexidecimal_reference
+      assert_equal 'hell&#x6F; world', escape('hell&#x6F; world')
+    end
+
+    def test_should_gracefully_handle_nonsense_hexidecimal_input
+      assert_equal '&#xABCDEF0123456789;', escape('&#xABCDEF0123456789;')
+    end
+
+    private
+
+    def escape(data)
+      NdrImport::Xml::ControlCharEscaper.new(data).escape!
+      data
+    end
+  end
+end


### PR DESCRIPTION
This PR follows on from #60.

XML can also embed characters (outside of a `CDATA` section) using referencing schemes of `&#nnnn;` (decimal) and `&#xhhhh;` (hexadecimal). These are then substituted for their character values by the XML parser (in our case, `libxml`).

What this PR proposes doing is handling such sequences, when they represent invalid [XML 1.0] control characters, in the same way as the underlying control characters would be - i.e. escaped before the parser can trip over them.

Additionally, we avoid running the escaping routines until we've once observed the parser having problems; this allows us to make a "best effort" at preserving any unescaped sequences in `CDATA` sections (where they are allowed and wouldn't on their own cause parsing problems - as they then interpreted as the literal sequence of characters `&, #, x, ...`).