### PR TITLE
Raise dependency on the 7zip gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-*no unreleased changes*
+### Fixed
+* Bump `seven_zip_ruby` requirement for Ruby 2.7 support
 
 ## 10.1.1 / 2021-03-15
 ### Fixed

--- a/ndr_import.gemspec
+++ b/ndr_import.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ooxml_decrypt'
   spec.add_dependency 'pdf-reader', '~> 2.1'
   spec.add_dependency 'roo-xls'
-  spec.add_dependency 'seven_zip_ruby', '~> 1.2'
+  spec.add_dependency 'seven_zip_ruby', '~> 1.3'
   spec.add_dependency 'spreadsheet', '1.2.6'
 
   spec.required_ruby_version = '>= 2.5'


### PR DESCRIPTION
The 7zip library doesn't play nicely on linux at v1.2; this PR bumps the gem's minimum requirement to v1.3.

Projects using released versions of `ndr_import` can bump their own requirement manually, in the interim.