### PR TITLE
Run test workflow against PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,13 @@
 name: Test
 
-on: [push]
+on:
+  # Run on all master branch commits
+  push:
+    branches:
+      - master
+
+  # Run against all PRs (from the main repo, or forks)
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
### Summary

As shown in PR #71,  there's an issue with the Actions config that prevents the tests running on PRs from forks.

This PR alters that config, so that the tests are triggered by any PR, and additionally against every commit _on master_.

#### Gained

* the ability to run tests against PRs coming from forks

#### Lost

* the ability for tests to have been pre-run for PRs coming from branches in this repo (i.e., while the PR is being authored).