### PR TITLE
# Fix test failures resulting from Nokogiri bump (CVE-2022-24836)

### DIFF
--- a/test/file/pdf_test.rb
+++ b/test/file/pdf_test.rb
@@ -15,8 +15,8 @@ module NdrImport
         handler.tables.each do |tablename, sheet|
           assert_nil tablename
           assert_instance_of Enumerator, sheet
-          assert_equal ['Hello                                         World', '',
-                        'Goodbye                                       Universe'], sheet.to_a
+          assert_equal ['Hello                                      World', '',
+                        'Goodbye                                    Universe'], sheet.to_a
         end
       end
 

--- a/test/file/registry_test.rb
+++ b/test/file/registry_test.rb
@@ -36,8 +36,8 @@ module NdrImport
         tables.each do |tablename, sheet|
           assert_nil tablename
           assert_instance_of Enumerator, sheet
-          assert_equal ['Hello                                         World', '',
-                        'Goodbye                                       Universe'], sheet.to_a
+          assert_equal ['Hello                                      World', '',
+                        'Goodbye                                    Universe'], sheet.to_a
         end
       end
 

--- a/test/helpers/file/pdf_test.rb
+++ b/test/helpers/file/pdf_test.rb
@@ -15,8 +15,8 @@ class PdfTest < ActiveSupport::TestCase
 
   test 'read_pdf_file helper should read pdf file' do
     file_content = @importer.send(:read_pdf_file, @permanent_test_files.join('hello_world.pdf'))
-    assert_equal ['Hello                                         World', '',
-                  'Goodbye                                       Universe'], file_content
+    assert_equal ['Hello                                      World', '',
+                  'Goodbye                                    Universe'], file_content
   end
 
   test 'read_pdf_file helper should raise exception on invalid pdf file' do


### PR DESCRIPTION
This PR fixes white space test failures on ruby 2.6x and 2.7x

A further PR will be needed to address the errors on ruby 3.1.1