### PR TITLE
Ndr import table metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 ### Fixed
 * Support Rails 8.1, Ruby 4.0. Drop support for Ruby 3.2
+* Allow direct assignment of `table.table_metadata`
 
 ## 11.4.1 / 2025-11-05
 ### Fixed

--- a/lib/ndr_import/table.rb
+++ b/lib/ndr_import/table.rb
@@ -11,9 +11,9 @@ module NdrImport
     include NdrImport::Mapper
 
     def self.all_valid_options
-      %w[canonical_name delimiter liberal_parsing filename_pattern file_password last_data_column
-         tablename_pattern header_lines footer_lines format klass columns slurp row_identifier
-         significant_mapped_fields]
+      %w[canonical_name delimiter liberal_parsing filename_pattern file_password
+         last_data_column tablename_pattern header_lines footer_lines
+         format klass columns slurp row_identifier significant_mapped_fields table_metadata]
     end
 
     def all_valid_options

--- a/lib/ndr_import/universal_importer_helper.rb
+++ b/lib/ndr_import/universal_importer_helper.rb
@@ -66,6 +66,7 @@ module NdrImport
         'slurp'                      => table_mapping.try(:slurp),
         'yield_xml_record'           => table_mapping.try(:yield_xml_record),
         'pattern_match_record_xpath' => table_mapping.try(:pattern_match_record_xpath),
+        'file_metadata'              => table_mapping.try(:file_metadata),
         'xml_file_metadata'          => table_mapping.try(:xml_file_metadata),
         'vcf_file_metadata'          => table_mapping.try(:vcf_file_metadata) }
     end
@@ -80,7 +81,7 @@ module NdrImport
         next if mapping.nil?
 
         mapping.notifier = get_notifier(record_total(filename, table_content))
-        mapping.table_metadata = file_metadata || {}
+        mapping.table_metadata ||= file_metadata || {}
         yield(mapping, table_content)
       end
     end

--- a/lib/ndr_import/universal_importer_helper.rb
+++ b/lib/ndr_import/universal_importer_helper.rb
@@ -66,7 +66,6 @@ module NdrImport
         'slurp'                      => table_mapping.try(:slurp),
         'yield_xml_record'           => table_mapping.try(:yield_xml_record),
         'pattern_match_record_xpath' => table_mapping.try(:pattern_match_record_xpath),
-        'file_metadata'              => table_mapping.try(:file_metadata),
         'xml_file_metadata'          => table_mapping.try(:xml_file_metadata),
         'vcf_file_metadata'          => table_mapping.try(:vcf_file_metadata) }
     end
@@ -81,7 +80,9 @@ module NdrImport
         next if mapping.nil?
 
         mapping.notifier = get_notifier(record_total(filename, table_content))
-        mapping.table_metadata ||= file_metadata || {}
+        # Merge file_metadata (from VCF or XML) with directly assigned table_metadata
+        # to form `table_metadata`
+        mapping.table_metadata = (mapping.table_metadata || {}).merge(file_metadata || {})
         yield(mapping, table_content)
       end
     end

--- a/lib/ndr_import/universal_importer_helper.rb
+++ b/lib/ndr_import/universal_importer_helper.rb
@@ -73,7 +73,7 @@ module NdrImport
 
     # This method does the table row yielding for the extract method, setting the notifier
     # so that we can monitor progress
-    def yield_tables_and_their_content(filename, tables, &block)
+    def yield_tables_and_their_content(filename, tables, &)
       return enum_for(:yield_tables_and_their_content, filename, tables) unless block_given?
 
       tables.each do |tablename, table_content, file_metadata|

--- a/test/non_tabular/table_test.rb
+++ b/test/non_tabular/table_test.rb
@@ -50,7 +50,7 @@ STR
     valid_options = %w[
       canonical_name capture_end_line capture_start_line columns end_in_a_record end_line_pattern
       filename_pattern file_password format klass remove_lines row_identifier
-      significant_mapped_fields start_in_a_record start_line_pattern
+      significant_mapped_fields start_in_a_record start_line_pattern table_metadata
     ]
     assert_equal valid_options.sort,
                  NdrImport::NonTabular::Table.all_valid_options.sort

--- a/test/universal_importer_helper_test.rb
+++ b/test/universal_importer_helper_test.rb
@@ -266,4 +266,22 @@ class UniversalImporterHelperTest < ActiveSupport::TestCase
       assert_equal({ 'hello' => 'world' }, table.table_metadata)
     end
   end
+
+  test 'should merge file metadata with directly assigned metadata' do
+    table_mapping =
+      NdrImport::Xml::Table.new(filename_pattern: /.xml/i,
+                                yield_xml_record: true,
+                                xml_record_xpath: 'BreastRecord',
+                                format: 'xml_table',
+                                xml_file_metadata: { record_count: '//COSD:RecordCount/@value' },
+                                table_metadata: { hello: 'world' },
+                                klass: 'SomeTestClass',
+                                columns: {})
+
+    source_file = @permanent_test_files.join('complex_xml.xml')
+    @test_importer.stubs(:get_table_mapping).returns(table_mapping)
+    @test_importer.extract(source_file) { |table, rows| table.transform(rows) }
+
+    assert_equal({ record_count: '6349923', hello: 'world' }, table_mapping.table_metadata)
+  end
 end

--- a/test/universal_importer_helper_test.rb
+++ b/test/universal_importer_helper_test.rb
@@ -248,4 +248,22 @@ class UniversalImporterHelperTest < ActiveSupport::TestCase
 
     assert_equal({ record_count: '6349923' }, table_mapping.table_metadata)
   end
+
+  test 'should allow assigning to table_metadata directly in table definition' do
+    table_mappings = [
+      NdrImport::Table.new(filename_pattern: /\.xls\z/i,
+                           header_lines: 1,
+                           footer_lines: 0,
+                           table_metadata: { 'hello' => 'world' },
+                           klass: 'SomeTestClass',
+                           columns: [{ 'column' => '1a' }])
+    ]
+    source_file = @permanent_test_files.join('sample_xls.xls')
+    @test_importer.stubs(:get_table_mapping).returns(table_mappings.first)
+    @test_importer.extract(source_file) do |table, _rows|
+      assert_instance_of NdrImport::Table, table
+
+      assert_equal({ 'hello' => 'world' }, table.table_metadata)
+    end
+  end
 end

--- a/test/vcf/table_test.rb
+++ b/test/vcf/table_test.rb
@@ -12,8 +12,8 @@ module Vcf
 
     test 'test_all_valid_options' do
       valid_options = %w[canonical_name columns file_password filename_pattern format klass
-                         last_data_column liberal_parsing row_identifier
-                         significant_mapped_fields slurp tablename_pattern vcf_file_metadata]
+                         last_data_column liberal_parsing row_identifier significant_mapped_fields
+                         slurp table_metadata tablename_pattern vcf_file_metadata]
       assert_equal valid_options.sort, NdrImport::Vcf::Table.all_valid_options.sort
     end
 


### PR DESCRIPTION
Previously, `table_metadata` could only be assigned to for VCF and XML tables, each with their own requirements.

This PR allows `table_metadata` to be directly assigned to in the `NdrImport::Table` definition, making is available to all `NdrImport::Table` classes.
