### PR TITLE
Keep NONET when overriding Nokogiri parse options

### DIFF
--- a/lib/ndr_import/file/xml.rb
+++ b/lib/ndr_import/file/xml.rb
@@ -57,8 +57,9 @@ module NdrImport
       def metadata_from_stream(xpath)
         cursor = Cursor.new(xpath, false)
 
-        # If markup isn't well-formed, try to work around it:
-        options = Nokogiri::XML::ParseOptions::RECOVER
+        # If markup isn't well-formed, try to work around it (but keep NONET,
+        # so external entities/DTDs can't trigger network requests):
+        options = Nokogiri::XML::ParseOptions::RECOVER | Nokogiri::XML::ParseOptions::NONET
         reader  = Nokogiri::XML::Reader(@stream, nil, @encoding, options)
 
         reader.each do |node|

--- a/lib/ndr_import/helpers/file/xml_streaming.rb
+++ b/lib/ndr_import/helpers/file/xml_streaming.rb
@@ -183,8 +183,9 @@ module NdrImport
           # Track nesting as the cursor moves through the document:
           cursor = Cursor.new(node_xpath, pattern_match_xpath)
 
-          # If markup isn't well-formed, try to work around it:
-          options = Nokogiri::XML::ParseOptions::RECOVER
+          # If markup isn't well-formed, try to work around it (but keep NONET,
+          # so external entities/DTDs can't trigger network requests):
+          options = Nokogiri::XML::ParseOptions::RECOVER | Nokogiri::XML::ParseOptions::NONET
           reader  = Nokogiri::XML::Reader(io, nil, encoding, options)
 
           reader.each do |node|


### PR DESCRIPTION
# Pull Request Details

## What?

Restores Nokogiri's `NONET` parse option in our two streaming XML readers, so that parsing an XML file can never trigger outbound network requests (e.g. fetching external DTDs or entities referenced by the document).

## Why?

When we pass `RECOVER` explicitly to `Nokogiri::XML::Reader`, we replace Nokogiri's defaults (`RECOVER | NONET | BIG_LINES`) rather than adding to them — silently dropping `NONET`. Since this library ingests files from external sources, a crafted document referencing a remote DTD could cause the importing server to make attacker-directed network requests (SSRF-style). This closes that gap as defence in depth; entity substitution (`NOENT`/`DTDLOAD`) was already off, so no data-disclosure XXE path existed.

## How?

A one-line change at each of the two `Nokogiri::XML::Reader` call sites (`lib/ndr_import/file/xml.rb`, `lib/ndr_import/helpers/file/xml_streaming.rb`): `RECOVER` becomes `RECOVER | NONET`, with a comment explaining why the flag must be kept when overriding options.

## Testing?

Existing XML streaming test suite covers these code paths; the change only removes a capability (network fetches during parse) that no legitimate input relies on. A security review of the change and the wider `lib/` tree confirmed no remaining XML parsing sink is missing `NONET`.

## AI Contribution?

Claude (Fable 5, via Claude Code) performed the security review that identified the dropped `NONET` flag and drafted this PR description. The code change was human-authored and human-reviewed.

## Screenshots (optional)

N/A — no user-facing output changes.

## Anything Else?

If we ever add another explicit-options Nokogiri call site, the same trap applies: prefer starting from `Nokogiri::XML::ParseOptions::DEFAULT_XML` and adding flags, rather than building the option set from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)